### PR TITLE
Async course update script

### DIFF
--- a/app.py
+++ b/app.py
@@ -535,12 +535,13 @@ def admin_courses():
 
     groups_by_dept, dept_course_data = getMetrics()
 
-    html = render_template('admin_courses_new.html',
-                           netid=netid,
-                           isAdmin=isAdmin(netid),
-                           groups_by_dept=groups_by_dept,
-                           dept_course_data=dept_course_data,
-                           )
+    html = render_template(
+        "admin_courses_new.html",
+        netid=netid,
+        isAdmin=isAdmin(netid),
+        groups_by_dept=groups_by_dept,
+        dept_course_data=dept_course_data,
+    )
     response = make_response(html)
     return response
 

--- a/app.py
+++ b/app.py
@@ -417,7 +417,7 @@ def start_new_semester():
     # elif sem == "summer":
     #     term += 2
 
-    reset_classes(netid)
+    os.system(f"python update_courses.py {netid} &")
 
     return redirect("admin")
 

--- a/database.py
+++ b/database.py
@@ -156,13 +156,15 @@ def getAdmin():
 
     return admins
 
+
 # ---------------------------------------------------------------------
 # --- METRICS ----
+
 
 def getMetrics():
     all_classes, all_group_info, all_group_assignment = _getGroupData()
 
-    groups_by_id = {} # key is groupid, value is list of netids
+    groups_by_id = {}  # key is groupid, value is list of netids
     for row in all_group_assignment:
         assignment_row = GroupAssignment(row)
         group_id = str(assignment_row.getGroupId())
@@ -170,7 +172,7 @@ def getMetrics():
 
         if group_id not in groups_by_id:
             groups_by_id[group_id] = []
-        
+
         groups_by_id[group_id].append(net_id)
 
     """
@@ -208,7 +210,7 @@ def getMetrics():
         },
         ...
     }
-    """ 
+    """
     groups_by_dept = {}
 
     # every class should have an entry, even if it has no groups
@@ -221,23 +223,23 @@ def getMetrics():
         if dept not in groups_by_dept:
             groups_by_dept[dept] = {}
             dept_course_data[dept] = {
-                'courses': {},
-                'num_unique_students': 0,
-                'num_groups': 0,
-                'num_courses_total': 0,
-                'num_courses_with_groups': 0,
+                "courses": {},
+                "num_unique_students": 0,
+                "num_groups": 0,
+                "num_courses_total": 0,
+                "num_courses_with_groups": 0,
             }
 
         if num not in groups_by_dept[dept]:
             groups_by_dept[dept][num] = {}
-            dept_course_data[dept]['courses'][num] = {
-                'title': title,
-                'num_unique_students': 0,
-                'num_groups': 0,
+            dept_course_data[dept]["courses"][num] = {
+                "title": title,
+                "num_unique_students": 0,
+                "num_groups": 0,
             }
-        
+
         # increment total number of courses per dept
-        dept_course_data[dept]['num_courses_total'] += 1
+        dept_course_data[dept]["num_courses_total"] += 1
 
     for row in all_group_info:
         group_row = StudyGroup(row)
@@ -251,7 +253,7 @@ def getMetrics():
 
         group_netids = groups_by_id[group_id]
         groups_by_dept[dept][num][group_id].extend(group_netids)
-        
+
     for dept in groups_by_dept:
         dept_students_set = set()
         dept_num_groups = 0
@@ -259,12 +261,12 @@ def getMetrics():
         for num in groups_by_dept[dept]:
             # number of groups in this course
             course_num_groups = len(groups_by_dept[dept][num])
-            dept_course_data[dept]['courses'][num]['num_groups'] = course_num_groups 
+            dept_course_data[dept]["courses"][num]["num_groups"] = course_num_groups
             dept_num_groups += course_num_groups
 
             # increment number of courses with groups
             if course_num_groups > 0:
-                dept_course_data[dept]['num_courses_with_groups'] += 1
+                dept_course_data[dept]["num_courses_with_groups"] += 1
 
             course_students_set = set()
             for group_id in groups_by_dept[dept][num]:
@@ -273,13 +275,15 @@ def getMetrics():
                 dept_students_set.update(group_set)
 
             # number of unique students in this course
-            dept_course_data[dept]['courses'][num]['num_unique_students'] = len(course_students_set)
-        
+            dept_course_data[dept]["courses"][num]["num_unique_students"] = len(
+                course_students_set
+            )
+
         # number of unique students in this dept
-        dept_course_data[dept]['num_unique_students'] = len(dept_students_set)
+        dept_course_data[dept]["num_unique_students"] = len(dept_students_set)
 
         # number of groups in this dept
-        dept_course_data[dept]['num_groups'] = dept_num_groups
+        dept_course_data[dept]["num_groups"] = dept_num_groups
 
     # sort by increasing course number
     for dept in groups_by_dept:
@@ -289,6 +293,7 @@ def getMetrics():
     groups_by_dept = dict(sorted(groups_by_dept.items()))
 
     return groups_by_dept, dept_course_data
+
 
 def _getGroupData():
     conn = db.connect()
@@ -899,6 +904,7 @@ def reset_classes(netid):
     conn.execute(stmt)
 
     # start a new cycle
+    # term argument isn't used anymore
     stmt = cycle.insert().values(netid=netid, start=date.today(), term=str("1223"))
     conn.execute(stmt)
     conn.close()

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -26,7 +26,7 @@
           <div class="admin-boxes">
             <h5>Semester Information</h5>
             <hr>
-            The semester in progress is {{cycle.getSemester()}}. It was launched by {{cycle.getNetid()}} on {{cycle.getStart()}}.
+            The semester in progress was launched by {{cycle.getNetid()}} on {{cycle.getStart()}}.
             <hr>
             <p style = 'border:3px; border-style:solid; border-color:#FF0000; border-radius: 1vw;padding: 1em;'>
               Starting a new semester will delete all current information from the database. There is no way to undo this. 

--- a/update_courses.py
+++ b/update_courses.py
@@ -1,0 +1,10 @@
+from database import reset_classes
+from sys import argv, exit
+
+if __name__ == "__main__":
+    if len(argv) != 2:
+        print("Missing netID argument: python update_courses.py netID")
+        exit(1)
+
+    netid = argv[1]
+    reset_classes(netid)


### PR DESCRIPTION
## Summary

The course update script triggered by the `start_new_semester` endpoint was running synchronously and was subject to the 30s Heroku timeout. Because the course update script takes longer than 30 seconds, it was being cut off and many courses were missing from the database.

This PR moves the course update script to an external script that's run async via `os.system` so that is avoids the 30s timeout.