### PR TITLE
Generalize course policies

### DIFF
--- a/app.py
+++ b/app.py
@@ -311,8 +311,6 @@ def searchResults():
                 + str(course.getDept())
                 + '" data-num="'
                 + str(course.getNum())
-                + '" data-notes="'
-                + str(course.getNotes())
                 + '"<h6>Join</h6> </button>'
                 + " </td>\n</tr>\n"
             )
@@ -746,7 +744,7 @@ def submit_course_edits():
         endorse_status = 0
     else:
         endorse_status = 2
-    notes = request.args.get("notes")
+    notes = "" # leave this as empty string since it's not used anymore
 
     action = approveCourse(dept, classnum, endorse_status, notes)
     if action is not None:

--- a/templates/admin_edit_course.html
+++ b/templates/admin_edit_course.html
@@ -55,12 +55,6 @@
                         </div>
                       </div>
                       <div class="row">
-                        <div class="col-2"><strong>Instructor Notes</strong></div>
-                        <div class="col-10">
-                          <textarea name="notes" form="editform" style="width:100%;">{{ course.getNotes() }}</textarea><br><br>
-                        </div>
-                      </div>
-                      <div class="row">
                         <div class="col-12">
                           <input class="btn" type="btn" onclick="window.history.back();" value="Cancel">
                           <input type="submit" class="btn" value="Submit">

--- a/templates/index.html
+++ b/templates/index.html
@@ -41,10 +41,10 @@
             </div>      
             <!-- Modal body -->
             <div class="modal-body">
-            <div style="margin: 1em;">By using joining a group on TigerStudy for this class, you are <strong>agreeing to respect all of Princeton's collaboration policies</strong>,
-              including general Honor Code rules and also course-specific guidelines.</div>
-            
-              <span id="instructor-notes"> </span>
+            <div class="mb-3">
+              By joining a TigerStudy group for this class, you agree to <strong>follow all
+              course collaboration policies</strong> and <strong>abide by the Honor Code</strong>.
+            </div>
             
               <form action="joinClass" id="join-class" method="get">
                 <input type="hidden" id="join-dept" name="dept" value="">
@@ -72,14 +72,8 @@
 						//get data-netid attribute of the clicked element
 						let dept = $(this).attr('data-dept');
             let num = $(this).attr('data-num');
-            let inst_notes = $(this).attr('data-notes');
-            if (inst_notes != "") {
-              inst_notes = '<p style = "border:3px; border-style:solid; border-color:#FF0000; border-radius: 1vw; padding: 1em; margin:1em">' + 
-              "Your instructor wants to remind you of course policies. Please review the following note: <br> <strong>" + inst_notes + "</strong></p>"
-            }
 						$("input[id='join-dept']").val(dept);
             $("input[id='join-num']").val(num);
-            $("span[id='instructor-notes']").html(inst_notes);
             $("span[id='join-dept-header']").html(dept);
             $("span[id='join-num-header']").html(num);
 


### PR DESCRIPTION
## Summary

One of the requested changes was to remove the ability for instructors to provide course-specific notes/policies. These notes/polices would be displayed in a modal before a student is able to join a study group. Instead, the "terms and conditions" statement is now more general and leaves it to the student to check course collaboration policies. This change makes the app less maintenance-heavy.

<img width="1183" alt="CleanShot 2023-02-25 at 23 43 39@2x" src="https://user-images.githubusercontent.com/13815069/221392747-987dd210-fe49-4dc8-8992-0cc576430d50.png">


This PR also removes the ability for admins to add/edit course-specific notes, since they're not displayed anymore.